### PR TITLE
Total revenue merchant

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'active_designer'
 gem 'faker'
 gem 'factory_bot_rails'
 gem 'jsonapi-serializer'
+gem 'database_cleaner-active_record'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,10 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
+    database_cleaner-active_record (2.0.1)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
     diff-lcs (1.4.4)
     docile (1.4.0)
     erubi (1.10.0)
@@ -170,6 +174,7 @@ PLATFORMS
 DEPENDENCIES
   active_designer
   bootsnap (>= 1.1.0)
+  database_cleaner-active_record
   factory_bot_rails
   faker
   jsonapi-serializer

--- a/app/controllers/api/v1/items/merchant_controller.rb
+++ b/app/controllers/api/v1/items/merchant_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::Items::MerchantsController < ApplicationController
+class Api::V1::Items::MerchantController < ApplicationController
   
   def index
     item = Item.find(params[:item_id])

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -33,7 +33,7 @@ class Api::V1::ItemsController < ApplicationController
     item = Item.new(item_params)
 
     if item.save 
-      render json: ItemSerializer.new(item), status: 201, status: :created
+      render json: ItemSerializer.new(item), status: 201
     else 
       render json: {
         message: 'Invalid',

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::ItemsController < ApplicationController
 
   def index
+    # fetch it and then check if it's nil
     if params[:page].nil?
       page = params.fetch(:page, 1).to_i
     else 
@@ -45,7 +46,7 @@ class Api::V1::ItemsController < ApplicationController
     item = Item.find(params[:id])
     
     if item.update(item_params)
-      render json: ItemSerializer.new(@item), status: 201
+      render json: ItemSerializer.new(item), status: 201
     end 
 
     rescue ActiveRecord::RecordNotFound

--- a/app/controllers/api/v1/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants_controller.rb
@@ -1,9 +1,11 @@
 class Api::V1::MerchantsController < ApplicationController
   
   def index
-    if params[:page].nil? 
+    if params[:page].nil?
       page = params.fetch(:page, 1).to_i
-    else 
+    elsif params[:page].to_i <= 0
+      page = 1
+    else
       page = params[:page].to_i
     end
 

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -7,4 +7,11 @@ class Invoice < ApplicationRecord
   has_many :items, through: :invoice_items
   has_many :transactions, dependent: :destroy
   has_many :merchants, through: :items
+
+  def self.potential_revenue
+    joins(:invoice_items)
+    .select("invoices.id as id, sum(invoice_items.quantity * invoice_items.unit_price) as revenue")
+    .where.not(status: 'shipped')
+    .group(:id)
+  end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -2,10 +2,9 @@ class Invoice < ApplicationRecord
   validates :status, presence: true
   
   belongs_to :customer
+  belongs_to :merchant
   has_many :invoice_items, dependent: :destroy
   has_many :items, through: :invoice_items
   has_many :transactions, dependent: :destroy
   has_many :merchants, through: :items
-  
-  enum status: [:in_progress, :completed, :cancelled]
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,6 +6,4 @@ class Item < ApplicationRecord
   belongs_to :merchant
   has_many :invoice_items, dependent: :destroy
   has_many :invoices, through: :invoice_items
-  has_many :transactions, through: :invoices
-  has_many :customers, through: :invoices
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,4 +6,15 @@ class Item < ApplicationRecord
   belongs_to :merchant
   has_many :invoice_items, dependent: :destroy
   has_many :invoices, through: :invoice_items
+  has_many :transactions, through: :invoices
+
+  def self.rank_most_revenue
+    all
+    .joins(:invoices, :transactions, :invoice_items)
+    .where("invoices.status = ? and transactions.result = ?", 'shipped', 'success')
+    .select("items.*,
+            sum(invoice_items.quantity * invoice_items.unit_price) as revenue")
+    .order(revenue: :desc)
+    .group('items.id')
+  end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -11,15 +11,17 @@ class Merchant < ApplicationRecord
     invoices
     .joins(:transactions)
     .joins(:invoice_items)
-    .where("transactions.result = 'success' and invoices.status = 'shipped'")
+    .where("transactions.result = 'success' AND invoices.status = 'shipped'")
     .sum('invoice_items.quantity * invoice_items.unit_price')
-    
-    # invoices
-    # .joins(:transactions)
-    # .joins(:invoice_items)
-    # .where("invoices.status = 'shipped' and transactions.result = 'success'")
-    # .select("sum(invoice_items.quantity * invoice_items.unit_price) as revenue,
-    #                     items.merchant_id as merchant_id")
-    # .group('items.merchant_id')
+  end
+
+  def self.most_revenue
+    joins(:transactions, :invoice_items)
+    .select("merchants.name as name,
+             merchants.id as id,
+             sum(invoice_items.quantity * invoice_items.unit_price) as revenue")
+    .group(:name, :id)
+    .order(revenue: :desc)
+    .where("invoices.status = ? and transactions.result = ?", 'shipped', 'success')
   end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,9 +1,25 @@
 class Merchant < ApplicationRecord
   validates :name, presence: true
   
-  has_many :items, dependent: :destroy
+  has_many :items, dependent: :destroy  
+  has_many :invoices, dependent: :destroy
   has_many :invoice_items, through: :items
-  has_many :invoices, through: :invoice_items
   has_many :transactions, through: :invoices
   has_many :customers, through: :invoices
+
+  def revenue
+    invoices
+    .joins(:transactions)
+    .joins(:invoice_items)
+    .where("transactions.result = 'success' and invoices.status = 'shipped'")
+    .sum('invoice_items.quantity * invoice_items.unit_price')
+    
+    # invoices
+    # .joins(:transactions)
+    # .joins(:invoice_items)
+    # .where("invoices.status = 'shipped' and transactions.result = 'success'")
+    # .select("sum(invoice_items.quantity * invoice_items.unit_price) as revenue,
+    #                     items.merchant_id as merchant_id")
+    # .group('items.merchant_id')
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :items, except: [:new, :edit] do
-        resources :merchants, module: 'items', only: [:index]
+        resources :merchant, module: 'items', only: [:index]
       end
 
       resources :merchants, only: [:index, :show] do

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -34,8 +34,8 @@ ActiveRecord::Schema.define(version: 2021_07_17_194554) do
   end
 
   create_table "invoices", force: :cascade do |t|
-    t.bigint "merchant_id"
     t.bigint "customer_id"
+    t.bigint "merchant_id"
     t.string "status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -44,10 +44,10 @@ ActiveRecord::Schema.define(version: 2021_07_17_194554) do
   end
 
   create_table "items", force: :cascade do |t|
-    t.bigint "merchant_id"
     t.string "name"
     t.string "description"
     t.float "unit_price"
+    t.bigint "merchant_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["merchant_id"], name: "index_items_on_merchant_id"

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
     description { Faker::Hipster.paragraph }
     unit_price { Faker::Number.within(range: 1..1000) }
 
-    association :merchant, factory: :merchant
+    association :merchant, factory: :mock_merchant
   end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -12,4 +12,40 @@ RSpec.describe Invoice do
     it { should have_many :transactions }
     it { should have_many(:items).through(:invoice_items) }
   end
+
+  describe "class methods" do
+    describe '::potential_revenue' do
+      it 'returns potential revenue of invoices' do
+        merchant = create(:mock_merchant)
+
+        customer_1 = create(:mock_customer)
+        customer_2 = create(:mock_customer)
+        customer_3 = create(:mock_customer)
+
+        item_1 = create(:mock_item, merchant: merchant)
+        item_2 = create(:mock_item, merchant: merchant)
+        item_3 = create(:mock_item, merchant: merchant)
+
+        invoice_1 = create(:mock_invoice, merchant_id: merchant.id, customer: customer_1, status: 'packaged')
+        invoice_2 = create(:mock_invoice, merchant_id: merchant.id, customer: customer_1, status: 'packaged')
+        invoice_3 = create(:mock_invoice, merchant_id: merchant.id, customer: customer_2, status: 'shipped')
+        invoice_4 = create(:mock_invoice, merchant_id: merchant.id, customer: customer_2, status: 'packaged')
+        invoice_5 = create(:mock_invoice, merchant_id: merchant.id, customer: customer_3, status: 'shipped')
+        invoice_6 = create(:mock_invoice, merchant_id: merchant.id, customer: customer_3, status: 'packaged')
+
+        invoice_item_1 = create(:mock_invoice_item, item: item_1, invoice: invoice_1, quantity: 18, unit_price: 1000.00)
+        invoice_item_2 = create(:mock_invoice_item, item: item_2, invoice: invoice_2, quantity: 12, unit_price: 20000.99)
+        invoice_item_3 = create(:mock_invoice_item, item: item_3, invoice: invoice_3, quantity: 5, unit_price: 24403.91)
+        invoice_item_4 = create(:mock_invoice_item, item: item_1, invoice: invoice_4, quantity: 10, unit_price: 100)
+        invoice_item_5 = create(:mock_invoice_item, item: item_2, invoice: invoice_5, quantity: 2, unit_price: 4000)
+        invoice_item_5 = create(:mock_invoice_item, item: item_3, invoice: invoice_6, quantity: 5, unit_price: 80)
+        
+        transaction_1 = create(:mock_transaction, invoice: invoice_1, result: 'success')
+        transaction_2 = create(:mock_transaction, invoice: invoice_2, result: 'success')
+        transaction_3 = create(:mock_transaction, invoice: invoice_3, result: 'success')
+        
+        expect(Invoice.potential_revenue).to eq(259411.88)
+      end
+    end
+  end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe Invoice do
   
   describe 'relationships' do
     it { should belong_to :customer }
+    it { should belong_to :merchant } 
     it { should have_many :invoice_items }
     it { should have_many :transactions }
     it { should have_many(:items).through(:invoice_items) }
-    it { should have_many(:merchants).through(:items) }
   end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -44,7 +44,10 @@ RSpec.describe Invoice do
         transaction_2 = create(:mock_transaction, invoice: invoice_2, result: 'success')
         transaction_3 = create(:mock_transaction, invoice: invoice_3, result: 'success')
         
-        expect(Invoice.potential_revenue).to eq(259411.88)
+        first = Invoice.potential_revenue.first
+
+        expect(first.id).to eq(invoice_1.id)
+        expect(first.revenue).to eq(1800.0)
       end
     end
   end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -12,4 +12,59 @@ RSpec.describe Item, type: :model do
     it { should have_many :invoice_items }
     it { should have_many(:invoices).through(:invoice_items) }
   end
+
+  describe 'class methods' do
+    describe "::rank_most_revenue" do
+      xit 'returns items ranked by revenue' do
+        # merchant = create(:mock_merchant)
+        # merchant_2 = create(:mock_merchant)
+
+        # item_1 = create(:mock_item, merchant: merchant)
+        # item_2 = create(:mock_item, merchant: merchant)
+        # item_3 = create(:mock_item, merchant: merchant_2)
+
+        # customer_1 = create(:mock_customer)
+        # customer_2 = create(:mock_customer)
+        # customer_3 = create(:mock_customer)
+
+        # invoice_1 = create(:mock_invoice, merchant_id: merchant.id, customer: customer_1)
+        # invoice_2 = create(:mock_invoice, merchant_id: merchant.id, customer: customer_2)
+        # invoice_3 = create(:mock_invoice, merchant_id: merchant_2.id, customer: customer_3)
+
+        # invoice_item_1 = create(:mock_invoice_item, item: item_1, invoice: invoice_1, quantity: 18, unit_price: 1000.00)
+        # invoice_item_2 = create(:mock_invoice_item, item: item_1, invoice: invoice_2, quantity: 12, unit_price: 20000.99)
+        # invoice_item_3 = create(:mock_invoice_item, item: item_2, invoice: invoice_3, quantity: 5, unit_price: 24403.91)
+  
+        # transaction_1 = create(:mock_transaction, invoice: invoice_1, result: 'success')
+        # transaction_2 = create(:mock_transaction, invoice: invoice_2, result: 'success')
+        # transaction_3 = create(:mock_transaction, invoice: invoice_3, result: 'success')
+        
+        merchant_1 = create(:mock_merchant)
+        merchant_2 = create(:mock_merchant)
+        merchant_3 = create(:mock_merchant)
+  
+        customer_1 = create(:mock_customer)
+        customer_2 = create(:mock_customer)
+        customer_3 = create(:mock_customer)
+  
+        item_1 = create(:mock_item, merchant: merchant_1)
+        item_2 = create(:mock_item, merchant: merchant_2)
+        item_3 = create(:mock_item, merchant: merchant_3)
+  
+        invoice_1 = create(:mock_invoice, merchant: merchant_1, customer: customer_1, status: 'shipped')
+        invoice_2 = create(:mock_invoice, merchant: merchant_2, customer: customer_2, status: 'shipped')
+        invoice_3 = create(:mock_invoice, merchant: merchant_3, customer: customer_3, status: 'shipped')
+  
+        invoice_item_1 = create(:mock_invoice_item, item: item_1, invoice: invoice_1, unit_price: 1)
+        invoice_item_2 = create(:mock_invoice_item, item: item_2, invoice: invoice_2, unit_price: 2)
+        invoice_item_3 = create(:mock_invoice_item, item: item_3, invoice: invoice_3, unit_price: 3)
+  
+        transaction_1 = create(:mock_transaction, invoice: invoice_1, result: 'success')
+        transaction_2 = create(:mock_transaction, invoice: invoice_2, result: 'success')
+        transaction_3 = create(:mock_transaction, invoice: invoice_3, result: 'success')
+        require 'pry'; binding.pry
+        expect(Item.rank_most_revenue).to eq(0)
+      end
+    end
+  end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -11,8 +11,5 @@ RSpec.describe Item, type: :model do
     it { should belong_to :merchant  }
     it { should have_many :invoice_items }
     it { should have_many(:invoices).through(:invoice_items) }
-    it { should have_many(:transactions).through(:invoices) }
-    it { should have_many(:invoices).through(:invoice_items) }
-    it { should have_many(:customers).through(:invoices) }
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Merchant, type: :model do
     it { should have_many(:transactions) }
   end
   
-  describe 'instance methods' do
+  describe 'class methods' do
     describe "::most_revenue" do
       it 'returns merchant with most revenue' do
         merchant_1 = create(:mock_merchant)

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -11,4 +11,34 @@ RSpec.describe Merchant, type: :model do
     it { should have_many(:invoice_items) }
     it { should have_many(:transactions) }
   end
+
+  describe 'instance methods' do
+    describe '#revenue' do
+      it 'returns the revenue according of given merchant' do
+        merchant = create(:mock_merchant)
+
+        customer_1 = create(:mock_customer)
+        customer_2 = create(:mock_customer)
+        customer_3 = create(:mock_customer)
+
+        item_1 = create(:mock_item, merchant: merchant)
+        item_2 = create(:mock_item, merchant: merchant)
+        item_3 = create(:mock_item, merchant: merchant)
+
+        invoice_1 = create(:mock_invoice, merchant_id: merchant.id, customer: customer_1, status: 'shipped')
+        invoice_2 = create(:mock_invoice, merchant_id: merchant.id, customer: customer_2, status: 'shipped')
+        invoice_3 = create(:mock_invoice, merchant_id: merchant.id, customer: customer_3, status: 'shipped')
+
+        invoice_item_1 = create(:mock_invoice_item, item: item_1, invoice: invoice_1, quantity: 18, unit_price: 1000.00)
+        invoice_item_2 = create(:mock_invoice_item, item: item_2, invoice: invoice_2, quantity: 12, unit_price: 20000.99)
+        invoice_item_3 = create(:mock_invoice_item, item: item_3, invoice: invoice_3, quantity: 5, unit_price: 24403.91)
+  
+        transaction_1 = create(:mock_transaction, invoice: invoice_1, result: 'success')
+        transaction_2 = create(:mock_transaction, invoice: invoice_2, result: 'success')
+        transaction_3 = create(:mock_transaction, invoice: invoice_3, result: 'success')
+        
+        expect(merchant.revenue).to eq(380031.43)
+      end
+    end
+  end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -11,6 +11,47 @@ RSpec.describe Merchant, type: :model do
     it { should have_many(:invoice_items) }
     it { should have_many(:transactions) }
   end
+  
+  describe 'instance methods' do
+    describe "::most_revenue" do
+      it 'returns merchant with most revenue' do
+        merchant_1 = create(:mock_merchant)
+        merchant_2 = create(:mock_merchant)
+        merchant_3 = create(:mock_merchant)
+  
+        customer_1 = create(:mock_customer)
+        customer_2 = create(:mock_customer)
+        customer_3 = create(:mock_customer)
+  
+        item_1 = create(:mock_item, merchant: merchant_1)
+        item_2 = create(:mock_item, merchant: merchant_2)
+        item_3 = create(:mock_item, merchant: merchant_3)
+  
+        invoice_1 = create(:mock_invoice, merchant: merchant_1, customer: customer_1, status: 'shipped')
+        invoice_2 = create(:mock_invoice, merchant: merchant_2, customer: customer_2, status: 'shipped')
+        invoice_3 = create(:mock_invoice, merchant: merchant_3, customer: customer_3, status: 'shipped')
+  
+        invoice_item_1 = create(:mock_invoice_item, item: item_1, invoice: invoice_1, quantity: 12, unit_price: 1)
+        invoice_item_2 = create(:mock_invoice_item, item: item_2, invoice: invoice_2, quantity: 20, unit_price: 2)
+        invoice_item_3 = create(:mock_invoice_item, item: item_3, invoice: invoice_3, quantity: 10, unit_price: 3)
+  
+        transaction_1 = create(:mock_transaction, invoice: invoice_1, result: 'success')
+        transaction_2 = create(:mock_transaction, invoice: invoice_2, result: 'success')
+        transaction_3 = create(:mock_transaction, invoice: invoice_3, result: 'success')
+        
+        first = Merchant.most_revenue.first
+        last = Merchant.most_revenue.last
+
+        expect(first.id).to eq(merchant_2.id)
+        expect(first.name).to eq(merchant_2.name)
+        expect(first.revenue).to eq(merchant_2.revenue)
+        
+        expect(last.id).to eq(merchant_1.id)
+        expect(last.name).to eq(merchant_1.name)
+        expect(last.revenue).to eq(merchant_1.revenue)
+      end
+    end
+  end
 
   describe 'instance methods' do
     describe '#revenue' do

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe Transaction do
     it { should validate_presence_of(:credit_card_number) }
     it { should validate_presence_of(:credit_card_expiration_date) }
     it { should validate_presence_of(:result) }
-    
   end
 
   describe 'relationships' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,6 +71,28 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+  config.before(:each) do
+      DatabaseCleaner.strategy = :transaction
+  end
+  config.before(:each, :js => true) do
+      DatabaseCleaner.strategy = :truncation
+  end
+  config.before(:each) do
+      DatabaseCleaner.start
+  end
+  config.after(:each) do
+      DatabaseCleaner.clean
+  end
+  config.before(:all) do
+      DatabaseCleaner.start
+  end
+  config.after(:all) do
+      DatabaseCleaner.clean
+  end
+
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/requests/api/v1/items/merchants_request_spec.rb
+++ b/spec/requests/api/v1/items/merchants_request_spec.rb
@@ -6,29 +6,13 @@ RSpec.describe "Item Merchant API" do
       merchant = create(:mock_merchant)
       item = create(:mock_item, merchant: merchant)
       
-      get "/api/v1/items/#{item.id}/merchants" 
+      get "/api/v1/items/#{item.id}/merchant" 
 
       expect(response).to be_successful
 
       body = JSON.parse(response.body, symbolize_names: true)
 
       expect(body[:data][:id]).to eq(merchant.id.to_s)
-    end
-
-    # this test is actually instantiating a merchant
-    xit 'sad path: cannot find item/s merchant' do
-      merchant = create(:mock_merchant)
-      item = create(:mock_item, merchant: merchant)
-
-      get "/api/v1/items/#{item.id}/merchants" 
-
-      expect(response).to be_successful
-
-      body = JSON.parse(response.body, symbolize_names: true)
-      
-      expect(body[:message]).to eq 'Not Found'
-      expect(body[:errors]).to include 'Could not find merchant with id#0'
-      expect(response.status).to eq(404)
     end
   end
 end

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Items API" do
 
   context 'items index' do
     before(:each) do
-      create_list(:mock_item, 25, merchant: @merchant)
+      create_list(:mock_item, 500, merchant: @merchant)
     end
 
     it 'sends 20 items max by default' do

--- a/spec/requests/api/v1/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants_request_spec.rb
@@ -1,14 +1,16 @@
 require 'rails_helper'
 
-RSpec.describe "Items API" do
+RSpec.describe "Merchants API" do
   before(:all) do
     @merchant = create(:mock_merchant)
   end
 
   context 'merchant index' do
-    it 'sends 20 merchants max by default' do
-      create_list(:mock_merchant, 25)
-      
+    before(:each) do
+      create_list(:mock_merchant, 500)
+    end
+
+    it 'sends 20 merchants max by default' do    
       get '/api/v1/merchants'
 
       expect(response).to be_successful
@@ -22,7 +24,7 @@ RSpec.describe "Items API" do
       get '/api/v1/merchants', params: { per_page: 50 }
 
       body = JSON.parse(response.body, symbolize_names: true)
-
+    
       expect(response).to be_successful
       expect(body[:data].size).to eq(50)
     end
@@ -53,11 +55,11 @@ RSpec.describe "Items API" do
       get "/api/v1/merchants/#{merchant.id}"
       
       body = JSON.parse(response.body, symbolize_names: true)
-
+      
       expect(response).to be_successful
       expect(body[:data][:id]).to eq("#{merchant.id}")
       expect(body[:data][:type]).to eq("merchant")
-      expect(body[:data][:attributes][:name]).to eq("Sawyer B. Hind")
+      expect(body[:data][:attributes][:name]).to eq(merchant.name)
     end
 
     it 'sad path: cannot find the merchant' do


### PR DESCRIPTION
This PR adds AR methods for the following business intelligence: 
- Total Revenue for a Given Merchant
- Merchants with Most Revenue
- Potential Revenue of Unshipped Orders, ranked by “potential” Revenue
-  Find items ranked by Revenue

Items is failing. 